### PR TITLE
Handle missing asteroid when depositing

### DIFF
--- a/IdleSpaceMiner/Assets/Script/Drone.cs
+++ b/IdleSpaceMiner/Assets/Script/Drone.cs
@@ -14,6 +14,7 @@ public class Drone : MonoBehaviour
     private Asteroid targetAsteroid;
     private Vector3 targetPosition;
     private int currentCargo = 0;
+    private ResourceType carriedResourceType;
 
     private enum State { Idle, FlyingToAsteroid, Mining, Returning }
     private State currentState = State.Idle;
@@ -107,6 +108,7 @@ public class Drone : MonoBehaviour
 
             if (currentCargo >= cargoCapacity || targetAsteroid.IsDepleted)
             {
+                carriedResourceType = targetAsteroid.resourceType;
                 laser.enabled = false;
                 targetPosition = station.transform.position;
                 currentState = State.Returning;
@@ -126,8 +128,12 @@ public class Drone : MonoBehaviour
 
             laser.enabled = false;
 
-            station.DepositResources(currentCargo, targetAsteroid.resourceType);
+            if (carriedResourceType != null && currentCargo > 0)
+                station.DepositResources(currentCargo, carriedResourceType);
+
             currentCargo = 0;
+            targetAsteroid = null;
+            carriedResourceType = null;
 
             currentState = State.Idle;
         }


### PR DESCRIPTION
## Summary
- Track the resource type a drone is carrying
- Avoid NullReference exceptions if the asteroid vanishes before depositing

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68952608370483249dc78c0b6a1e388d