### PR TITLE
Fix company name in ProjectSettings

### DIFF
--- a/IdleSpaceMiner/ProjectSettings/ProjectSettings.asset
+++ b/IdleSpaceMiner/ProjectSettings/ProjectSettings.asset
@@ -12,7 +12,7 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: PrimodialGenesis
+  companyName: PrimordialGenesis
   productName: com.redeamed.IdleSpaceMiner
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}


### PR DESCRIPTION
## Summary
- correct company name in Unity ProjectSettings from PrimodialGenesis to PrimordialGenesis

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895275ab0ac8324bfde1fb56f5c4aee